### PR TITLE
Load 5mb bundle

### DIFF
--- a/en.html
+++ b/en.html
@@ -211,6 +211,7 @@
         <br />
       </div>
   </div>
+  <script src="5mb-bundle.js"></script>
   <script src="./client.js"></script>
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-127958415-1"></script>
   <script>

--- a/ru.html
+++ b/ru.html
@@ -226,6 +226,7 @@
       <br />
     </div>
   </div>
+  <script src="5mb-bundle.js"></script>
   <script src="./client.js"></script>
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-127958415-1"></script>
   <script>


### PR DESCRIPTION
Generated by running `node -pe "'0+'.repeat(5 * 1024 * 1024 / 2 - 1) + '0'" > 5mb-bundle.js`.

Fixes [#1: Small bundle size](https://github.com/Bloomca/website-in-2018/issues/1).